### PR TITLE
Add Facebook Ad Library support

### DIFF
--- a/ai/data/datasets/facebook_ad_library.json
+++ b/ai/data/datasets/facebook_ad_library.json
@@ -1,0 +1,13 @@
+{
+    "category": "Social Media",
+    "endpoint": "facebook_ad_library",
+    "url": "https://graph.facebook.com/v18.0/ads_archive",
+    "title": "Facebook Ad Library",
+    "description": "Dataset definition for Facebook Ad Library API.",
+    "parameters": {
+        "ad_type": "POLITICAL_AND_ISSUE_ADS",
+        "ad_reached_countries": "US",
+        "search_terms": "<KEYWORDS>",
+        "access_token": "<ACCESS_TOKEN>"
+    }
+}


### PR DESCRIPTION
## Summary
- add dataset definition for the Facebook Ad Library API
- add `fetch_facebook_ads_library` function to query the Facebook API

## Testing
- `python -m py_compile ai/tools/data_fetcher.py`
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q` *(fails: No module named pytest)*